### PR TITLE
Add alternative Bar labels to quickPolish.R

### DIFF
--- a/R/quickPolish.R
+++ b/R/quickPolish.R
@@ -13,7 +13,7 @@
 #' @export
 quickPolish <- function(ce) {
   v <- '3.12'
-  samples_bar <- c('X14FE_no', 'X14FE_SL', 'X29FE_no', 'X29FE_SL', 'X41MA_no', 'X41MA_SL', 'D1D4_no', 'D1D4_SL', 'D4D5_no', 'D4D5_SL', 'Rep1_no', 'Rep1_SL', 'Rep2_no', 'Rep2_SL', 'Rep3_no', 'Rep3_SL', 'Rep4_no', 'Rep4_SL')
+  samples_bar <- c("FE14_no", "FE14_SL", "FE29_no", "FE29_SL", "MA41_no", "MA41_SL", 'X14FE_no', 'X14FE_SL', 'X29FE_no', 'X29FE_SL', 'X41MA_no', 'X41MA_SL', 'D1D4_no', 'D1D4_SL', 'D4D5_no', 'D4D5_SL', 'Rep1_no', 'Rep1_SL', 'Rep2_no', 'Rep2_SL', 'Rep3_no', 'Rep3_SL', 'Rep4_no', 'Rep4_SL')
   samples_oki <- c('DE1_no_T1', 'DE1_SL_T1', 'DE2_no_T1', 'DE2_SL_T1', 'EB1_no_T1', 'EB1_SL_T1', 'EB2_no_T1', 'EB2_SL_T1', 'EB3_no_T1', 'EB3_SL_T1')
   samples_osa <- c('D2_T1_no_T1', 'D2_T1_SL_T1', 'DE1_T1_no_T1', 'DE1_T1_SL_T1', 'DE2_T1_no_T1', 'DE2_T1_SL_T1', 'EB1_T1_no_T1', 'EB1_T1_SL_T1', 'EB2_T1_no_T1', 'EB2_T1_SL_T1', 'EB3_T1_no_T1', 'EB3_T1_SL_T1')
   ce$reads[CAGEr::sampleLabels(ce) %in% samples_bar] <- 'Bar'


### PR DESCRIPTION
Samples like `41MA_no` do not make nice column names in R, as  they get prefixed with `X` automatically.  I reloaded Bar data with fixed samples names where I put letters first (`MA41_no`), therefore adding them to `quickPolish`.